### PR TITLE
Add methods to prevent turret-based lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lag Detector Plugin
 A plugin that detects whenever a server's TPS is too low. Whenever the server TPS goes below a threshold, 
-the plugin will kill all units and destroy all payload sources.
+the plugin will kill all units, destroy all payload sources, and destroy all turrets.
 
 # How To Install
 ## Release Jar (recommended | most stable)
@@ -11,7 +11,6 @@ the plugin will kill all units and destroy all payload sources.
 4. Configure the plugin to your pleasure (note that `minimumTPS` is the ONLY configuration available).
 
 ## Source (not recommended | least stable)
-oh boy...
 1. Ensure that you have installed JDK 17
 2. Clone the repository onto your local machine via git
 3. Open your terminal (or command prompt if you're on Windows)

--- a/plugin.json
+++ b/plugin.json
@@ -2,6 +2,6 @@
   "name": "Lag Detector",
   "author": "LSN",
   "main": "org.lettsn.lag_detector.Main",
-  "description": "A plugin that restarts the server whenever the TPS drops below a certain threshold.",
-  "version": "0.1.0"
+  "description": "A plugin that destroys lag sources whenever the TPS drops below a given threshold.",
+  "version": "0.2.0"
 }

--- a/src/org/lettsn/lag_detector/V7/Utilities/CheckTPS.java
+++ b/src/org/lettsn/lag_detector/V7/Utilities/CheckTPS.java
@@ -27,8 +27,7 @@ public class CheckTPS{
             return;
         }
 
-        Call.sendMessage(String.format("%s: Killing all units and payload sources due to low server TPS.", pluginMessageName));
-        removeAllPayloadSources();
-        killAllUnits();
+        Call.sendMessage(String.format("%s: Killing all potential lag sources due to low TPS.", pluginMessageName));
+        runAll();
     }
 }

--- a/src/org/lettsn/lag_detector/V7/Utilities/KillMethods.java
+++ b/src/org/lettsn/lag_detector/V7/Utilities/KillMethods.java
@@ -3,12 +3,19 @@ package org.lettsn.lag_detector.V7.Utilities;
 import arc.struct.*;
 import mindustry.content.*;
 import mindustry.gen.*;
+import mindustry.world.meta.BlockGroup;
 
 public class KillMethods{
     // based on
     // https://github.com/mindustry-ddns-net/MapUtils/blob/master/src/main/java/xyz/semetrix/maputils/Commands/KillUnits/KillUnitsCommand.java
     // thanks, semetrix
     // (sorry to any randoms that have no access to that repository)
+    static void runAll() {
+        removeAllTurrets();
+        removeAllPayloadSources();
+        killAllUnits();
+    }
+
     static void killAllUnits() {
         Seq<Unit> units = Groups.unit.copy(new Seq<>()).select(Unitc::isAI);
 
@@ -20,5 +27,12 @@ public class KillMethods{
         Seq<Building> buildings = Groups.build.copy(new Seq<>()).select(building -> building.block == Blocks.payloadSource);
 
         buildings.forEach(Building::kill);
+    }
+
+    static void removeAllTurrets() {
+        Seq<Building> turrets = Groups.build.copy(new Seq<>()).select(building ->
+                building.block.group == BlockGroup.turrets);
+
+        turrets.forEach(Building::kill);
     }
 }


### PR DESCRIPTION
Add methods that prevent lag from turrets. Most noteable offenders being swarmers, but the code here will destroy all turrets. Additionally, moved all the destruction code into a "runAll" static method.